### PR TITLE
Fix /api/update-language parameter mismatch

### DIFF
--- a/src/app/api/update-language/route.ts
+++ b/src/app/api/update-language/route.ts
@@ -7,20 +7,20 @@ const supabase = createClient(
 )
 
 export async function POST(req: NextRequest) {
-  const { user_id, idioma } = await req.json()
+  const { user_id, language } = await req.json()
 
-  if (!user_id || !['es', 'en'].includes(idioma)) {
+  if (!user_id || !['es', 'en'].includes(language)) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
   }
 
   const { error } = await supabase
     .from('users')
-    .update({ preferred_language: idioma })
+    .update({ preferred_language: language })
     .eq('id', user_id)
 
   if (error) {
-    console.error('Supabase error al actualizar idioma:', error.message)
-    return NextResponse.json({ error: 'Failed to update idioma' }, { status: 500 })
+    console.error('Supabase error al actualizar language:', error.message)
+    return NextResponse.json({ error: 'Failed to update language' }, { status: 500 })
   }
 
   return NextResponse.json({ success: true })


### PR DESCRIPTION
## Summary
- replace `idioma` references with `language`
- accept `language` param and update `preferred_language`
- validate using `['es', 'en'].includes(language)`

## Testing
- `npm run lint` *(fails: several lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68464ff67dc88320a3b06300cd691bea